### PR TITLE
Code change to cover version 8 of pilight

### DIFF
--- a/lib/PilightWebsocket.js
+++ b/lib/PilightWebsocket.js
@@ -76,7 +76,7 @@ class PilightWebsocket {
      */
     handleMessage(json) {
         if (webSocketUtils.isMessageOfTypeValues(json)) {
-            this.handleValuesObject(json);
+            this.handleValuesObject(json.values);
         } else if (webSocketUtils.isMessageOfTypeUpdate(json)) {
             let deviceId = json.devices.join('-');
             let valueIds = Object.keys(json.values).filter(val => val !== 'timestamp');

--- a/lib/pilight/index.js
+++ b/lib/pilight/index.js
@@ -18,7 +18,7 @@ const DeviceTypes = {
 };
 
 const TypeRoleMap = {
-    'state': {role: 'switch', type: 'state'},
+    'state': {role: 'switch', type: 'boolean'},
     'battery': {role: 'indicator.battery', type: 'state'},
     'humidity': {role: 'value.humidity', type: 'state'},
     'temperature': {role: 'value.temperature', type: 'state'},

--- a/lib/ws/utils.js
+++ b/lib/ws/utils.js
@@ -48,10 +48,11 @@ class Utils {
      */
     isMessageOfTypeValues(json) {
         let result = false;
-        if (Array.isArray(json)) {
-            if (json.length === 0) {
+        if (json.message == 'values' && Array.isArray(json.values)) {
+            var values = json.values;
+            if (values.length === 0) {
                 result = true;
-            } else if (typeof json[0].type !== 'undefined' && typeof json[0].devices !== 'undefined' && typeof json[0].values !== 'undefined') {
+            } else if (typeof values[0].type !== 'undefined' && typeof values[0].devices !== 'undefined' && typeof values[0].values !== 'undefined') {
                 result = true;
             }
         }


### PR DESCRIPTION
The values-message of pilight has changed in version 8.
It now has the form:
```
{
  "message": "values",
  "values": [{
    "type": 1,
    "devices": ["Leiste1_1"],
    "values": {
      "timestamp": 0,
      "state": "on"
    }
  }, ...
```
I adapted the code to that.
- In PilightWebsocket.js I changed handleMessage() to give handleValuesObject() the values-part of the message.
- In ws\utils.js I changed isMessageOfTypeValues() to:
   + check that the message-part of the message is "values"
   + pass the values-part of the message to the exsiting checks.
With those changes the pilight adapter works again for me.